### PR TITLE
fix: Remove full page styling to allow use as component

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -25,8 +25,6 @@
   box-sizing: border-box;
   font-family: "Open Sans", sans-serif !important;
   margin: 0;
-  padding-bottom: 50px;
-  min-height: 100vh;
 
   @include cm-select;
   @include cm-app;


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->

## What?
<!-- Explain the changes you’ve made. It doesn’t need to be fancy
and you don’t have to get too technical, yet. Just explicit prose
on your net change will typically suffice. -->
Remove styling from the page component


## Why?
<!-- Explain both the engineering goal and also some business
objective that is satisfied or moved along -->
Allows rendering of page as a component. This allows uses such as displaying stylized text


## Testing?
<!-- Let the reviewer know how you tested the changes. Showing the
results of tests you’ve run is also very helpful. Let the reviewer
also know if some conditions or edge cases were not tested -->
Tested with `mycaptain-mentee-web` through `@commutatus/cm-page-builder-test`


## Anything Else?
<!-- You may want to delve into possible architecture changes or
technical debt here. Call out challenges, optimizations, etc. -->
Edit mode is not tested
